### PR TITLE
numpy dependency fixed

### DIFF
--- a/code/weather-data-to-db_requirements.txt
+++ b/code/weather-data-to-db_requirements.txt
@@ -4,3 +4,4 @@ pandas==1.5.3
 pyarrow==10.0.1
 cloud-sql-python-connector[pymysql]==1.2.0
 google-cloud-pubsub==2.15.2
+numpy==1.26.4


### PR DESCRIPTION
### Problem
The latest Numpy major release 2.0.0 (June 16th 2024) is no longer compatible with the version of Pandas used.

### Fix
Down versioning Numpy to 1.26.4 allows for the weather-data-to-db function to be deployed.